### PR TITLE
chore: added cooldown of 7 days to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 


### PR DESCRIPTION
# Please check before merging

- [x] Is the content of the `README.md` file still up-to-date?
- [ ] ~Have you added an entry to the `CHANGELOG.md`?~
- [x] Is the pull request title written in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

# Description

added cooldown of 7 days to dependabot.

Cooldown of 7 days was added because most of the security breaches of the dependencies will be resolved in about 7 days after occuring.
Because we wait 7 days after every dependency update, the most of the attacks will not affect us.
See [this blog](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) for further explanations